### PR TITLE
Update full title of event

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,8 +12,8 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: "Nilearn Days"
-subtitle: "Dev Days 2020"
+title: "Nilearn Dev Days 2020"
+subtitle: "Science and Software"
 description: >- # this means to ignore newlines until "baseurl:"
     Join online the Nilearn development community and shape what's next
 author: Nilearn team
@@ -42,5 +42,5 @@ url: "" # the base hostname & protocol for your site
 #google_analytics:
 
 # The following settings are NECESSARY for the Prologue theme to run:
-remote_theme: chrisbobbe/jekyll-theme-prologue 
+remote_theme: chrisbobbe/jekyll-theme-prologue
 collections: [sections]

--- a/_sections/intro.md
+++ b/_sections/intro.md
@@ -1,5 +1,5 @@
 ---
-title: Dev Days
+title: "Nilearn Dev Days: Science and Software"
 icon: fa-th
 order: 2
 ---

--- a/index.md
+++ b/index.md
@@ -3,8 +3,8 @@
 # Edit theme's home layout instead if you wanna make some changes
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: home
-title: Nilearn Dev Days 2020
-subtitle: Join online the Nilearn development community and shape what's next 
+title: "Nilearn Dev Days 2020: Science and Software"
+subtitle: Join online the Nilearn development community and shape what's next
 icon: fa-home
 order: 1
 cover-photo: assets/images/grandpre_pano.jpg
@@ -13,7 +13,7 @@ auto-header: none
 ---
 
 <header>
-  <h2 class="alt"><a href="http://http://nilearn.github.io/">Nilearn</a> Dev Days 2020 &mdash; 19-22 May</h2>
+  <h2 class="alt"><a href="http://http://nilearn.github.io/">Nilearn</a> Dev Days &mdash; 19-22 May 2020</h2>
   <p>Join online the Nilearn development community and shape what's next</p>
 </header>
 


### PR DESCRIPTION
Closes #11

- Updates full event name to "Nilearn Dev Days: Science and Software" based on @kchawla-pi feedback